### PR TITLE
enable lastmod git integration - cache busting

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -78,6 +78,10 @@ jobs:
       - name: build with hugo
         run: hugo --gc --verbose --baseURL ${{ env.web_url }}
 
+      # run a script to bust the cache on the site via cloudflare _headers file
+      - name: cache buster
+        run: script/cache-buster
+
       # this step is custom to my site and adds a 'commit' version to the site
       - name: write build version
         run: echo ${GITHUB_SHA} > ./public/version.txt

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,6 +65,10 @@ jobs:
       - name: build with hugo
         run: hugo --gc --verbose --baseURL ${{ env.web_url }}
 
+      # run a script to bust the cache on the site via cloudflare _headers file
+      - name: cache buster
+        run: script/cache-buster
+
       - name: write build version
         run: echo ${GITHUB_SHA} > ./public/version.txt
 

--- a/config.yml
+++ b/config.yml
@@ -10,6 +10,8 @@ enableEmoji: true
 enableRobotsTXT: true
 enableInlineShortcodes: true
 
+enableGitInfo: true
+
 buildDrafts: false
 buildFuture: false
 buildExpired: false

--- a/script/cache-buster
+++ b/script/cache-buster
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Create a Last-Modified header compliant date string
+lastModDate=$(date -u +"%a, %d %b %Y %H:%M:%S GMT")
+
+# replace {{ LastModHeader }} with the date string in the 'public/_headers' file
+sed -i -e "s/{{ LastModHeader }}/$lastModDate/g" public/_headers
+

--- a/script/cache-buster
+++ b/script/cache-buster
@@ -1,8 +1,12 @@
 #!/bin/bash
 
+# exit when any command fails
+set -e
+
 # Create a Last-Modified header compliant date string
 lastModDate=$(date -u +"%a, %d %b %Y %H:%M:%S GMT")
 
 # replace {{ LastModHeader }} with the date string in the 'public/_headers' file
 sed -i -e "s/{{ LastModHeader }}/$lastModDate/g" public/_headers
 
+echo "✅ Last-Modified header updated to: '$lastModDate'"

--- a/static/_headers
+++ b/static/_headers
@@ -1,1 +1,5 @@
 # https://developers.cloudflare.com/pages/platform/headers/
+
+# cache buster - the header value is replaced in CI
+https://blog.birki.io/*
+  Last-Modified: {{ LastModHeader }}

--- a/themes/PaperMod/layouts/partials/head.html
+++ b/themes/PaperMod/layouts/partials/head.html
@@ -2,9 +2,6 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-{{ $lastmodheader := now.Format "Mon, 02 Jan 2006 15:04:05 GMT" }}
-<meta http-equiv="Last-Modified" content="{{ $lastmodheader }}">
-
 {{- if hugo.IsProduction | or (eq site.Params.env "production") | and (ne .Params.robotsNoIndex true) }}
 <meta name="robots" content="index, follow">
 {{- else }}

--- a/themes/PaperMod/layouts/partials/head.html
+++ b/themes/PaperMod/layouts/partials/head.html
@@ -1,6 +1,10 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+{{ $lastmodheader := now.Format "Mon, 02 Jan 2006 15:04:05 GMT" }}
+<meta http-equiv="Last-Modified" content="{{ $lastmodheader }}">
+
 {{- if hugo.IsProduction | or (eq site.Params.env "production") | and (ne .Params.robotsNoIndex true) }}
 <meta name="robots" content="index, follow">
 {{- else }}

--- a/themes/PaperMod/layouts/partials/post_meta.html
+++ b/themes/PaperMod/layouts/partials/post_meta.html
@@ -1,7 +1,14 @@
 {{- $scratch := newScratch }}
 
+{{ $date := .Date.Format "02.01.2006" }}
+{{ $lastmod := .Lastmod.Format "02.01.2006" }}
+
 {{- if not .Date.IsZero -}}
 {{- $scratch.Add "meta" (slice (printf "<span title='%s'>%s</span>" (.Date) (.Date | time.Format (default "January 2, 2006" site.Params.DateFormat)))) }}
+{{- end }}
+
+{{- if ne $lastmod $date -}}
+{{- $scratch.Add "meta" (slice (printf "<span title='%s'>(updated %s)</span>" (.Lastmod) (.Lastmod | time.Format (default "January 2, 2006" site.Params.DateFormat)))) }}
 {{- end }}
 
 {{- if (.Param "ShowReadingTime") -}}


### PR DESCRIPTION
This pull request enables the `lastmod` git integration with Hugo. This PR also adds a new script that updates the Last-Modified header on cloudflare pages via the `_heaaders` file to globally bust the CDN cache