### PR TITLE
Variable Category Gradients

### DIFF
--- a/content/posts/branch-deploy/index.md
+++ b/content/posts/branch-deploy/index.md
@@ -8,7 +8,17 @@ summary: "Learn how to use the branch deploy model to ship code safely and quick
 
 date: 2023-08-10T00:00:00-00:00 # date of creation
 
-categories: ["engineering", "open source", "devops"] # high level categories
+# high level categories
+categories:
+  - name: "engineering"
+    gradient-start: "#4bb4e3"
+    gradient-end: "#2b94c3"
+  - name: "open source"
+    gradient-start: "#f46b45"
+    gradient-end: "#eea849"
+  - name: "devops"
+    gradient-start: "#f46b45"
+    gradient-end: "#eea849"
 tags: ["GitHub Actions", "deployment", "automation"] # micro level categories
 
 # aliases: ["markdown-example"] # redirect, alias, shorthand url

--- a/content/posts/branch-deploy/index.md
+++ b/content/posts/branch-deploy/index.md
@@ -12,16 +12,19 @@ tags: ["GitHub Actions", "deployment", "automation"] # micro level categories
 # aliases: ["markdown-example"] # redirect, alias, shorthand url
 
 categories: ["engineering", "open source", "devops"] # high level categories
-category-colors:
-  - name: "engineering"
-    gradient-start: "#4bb4e3"
-    gradient-end: "#2b94c3"
-  - name: "open source"
-    gradient-start: "#f46b45"
-    gradient-end: "#eea849"
-  - name: "devops"
-    gradient-start: "#f46b45"
-    gradient-end: "#eea849"
+categoryColors:
+  engineering:
+    gradientStart: "#007FEE"
+    gradientEnd: "#00DBD8"
+  open source:
+    gradientStart: "#7E25C7"
+    gradientEnd: "#F90183"
+  devops:
+    gradientStart: "#FF524C"
+    gradientEnd: "#F9C52A"
+
+banner:
+  headline: Try Tower For Free!
 
 ShowToc: true # show table of contents
 TocOpen: false # auto open table of contents

--- a/content/posts/branch-deploy/index.md
+++ b/content/posts/branch-deploy/index.md
@@ -8,17 +8,7 @@ summary: "Learn how to use the branch deploy model to ship code safely and quick
 
 date: 2023-08-10T00:00:00-00:00 # date of creation
 
-# high level categories
-categories:
-  - name: "engineering"
-    gradient-start: "#4bb4e3"
-    gradient-end: "#2b94c3"
-  - name: "open source"
-    gradient-start: "#f46b45"
-    gradient-end: "#eea849"
-  - name: "devops"
-    gradient-start: "#f46b45"
-    gradient-end: "#eea849"
+categories: ["engineering", "open source", "devops"] # high level categories
 tags: ["GitHub Actions", "deployment", "automation"] # micro level categories
 
 # aliases: ["markdown-example"] # redirect, alias, shorthand url

--- a/content/posts/branch-deploy/index.md
+++ b/content/posts/branch-deploy/index.md
@@ -8,10 +8,20 @@ summary: "Learn how to use the branch deploy model to ship code safely and quick
 
 date: 2023-08-10T00:00:00-00:00 # date of creation
 
-categories: ["engineering", "open source", "devops"] # high level categories
 tags: ["GitHub Actions", "deployment", "automation"] # micro level categories
-
 # aliases: ["markdown-example"] # redirect, alias, shorthand url
+
+categories: ["engineering", "open source", "devops"] # high level categories
+category-colors:
+  - name: "engineering"
+    gradient-start: "#4bb4e3"
+    gradient-end: "#2b94c3"
+  - name: "open source"
+    gradient-start: "#f46b45"
+    gradient-end: "#eea849"
+  - name: "devops"
+    gradient-start: "#f46b45"
+    gradient-end: "#eea849"
 
 ShowToc: true # show table of contents
 TocOpen: false # auto open table of contents

--- a/content/posts/example/index.md
+++ b/content/posts/example/index.md
@@ -8,7 +8,10 @@ summary: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed neque elit
 
 date: 2000-01-01T00:00:00-00:00 # date of creation
 
-categories: ["themes", "syntax"] # high level categories
+# high level categories
+categories:
+  - name: themes
+  - name: syntax
 tags: ["markdown", "css", "html", "themes"] # micro level categories
 
 aliases: ["markdown-example"] # redirect, alias, shorthand url

--- a/content/posts/example/index.md
+++ b/content/posts/example/index.md
@@ -8,10 +8,7 @@ summary: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed neque elit
 
 date: 2000-01-01T00:00:00-00:00 # date of creation
 
-# high level categories
-categories:
-  - name: themes
-  - name: syntax
+categories: ["themes", "syntax"] # high level categories
 tags: ["markdown", "css", "html", "themes"] # micro level categories
 
 aliases: ["markdown-example"] # redirect, alias, shorthand url

--- a/content/posts/example/index.md
+++ b/content/posts/example/index.md
@@ -8,10 +8,17 @@ summary: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed neque elit
 
 date: 2000-01-01T00:00:00-00:00 # date of creation
 
-categories: ["themes", "syntax"] # high level categories
 tags: ["markdown", "css", "html", "themes"] # micro level categories
-
 aliases: ["markdown-example"] # redirect, alias, shorthand url
+
+categories: ["themes", "syntax"] # high level categories
+category-colors:
+  - name: "themes"
+    gradient-start: "#4bb4e3"
+    gradient-end: "#2b94c3"
+  - name: "syntax"
+    gradient-start: "#f46b45"
+    gradient-end: "#eea849"
 
 ShowToc: true # show table of contents
 TocOpen: true # auto open table of contents

--- a/content/posts/example/index.md
+++ b/content/posts/example/index.md
@@ -12,13 +12,13 @@ tags: ["markdown", "css", "html", "themes"] # micro level categories
 aliases: ["markdown-example"] # redirect, alias, shorthand url
 
 categories: ["themes", "syntax"] # high level categories
-category-colors:
-  - name: "themes"
-    gradient-start: "#4bb4e3"
-    gradient-end: "#2b94c3"
-  - name: "syntax"
-    gradient-start: "#f46b45"
-    gradient-end: "#eea849"
+categoryColors:
+  themes:
+    gradientStart: "#007FEE"
+    gradientEnd: "#00DBD8"
+  syntax:
+    gradientStart: "#7E25C7"
+    gradientEnd: "#F90183"
 
 ShowToc: true # show table of contents
 TocOpen: true # auto open table of contents

--- a/themes/PaperMod/layouts/_default/list.html
+++ b/themes/PaperMod/layouts/_default/list.html
@@ -80,6 +80,7 @@
   {{- if not (.Param "hideMeta") }}
   <footer class="entry-footer">
     {{- partial "post_meta.html" . -}}
+    {{- partial "category_tags.html" . -}}
   </footer>
   {{- end }}
   <a class="entry-link" aria-label="post link to {{ .Title | plainify }}" href="{{ .Permalink }}"></a>

--- a/themes/PaperMod/layouts/_default/single.html
+++ b/themes/PaperMod/layouts/_default/single.html
@@ -18,20 +18,7 @@
       {{- partial "translation_list.html" . -}}
       {{- partial "edit_post.html" . -}}
       {{- partial "post_canonical.html" . -}}
-    </div>
-    {{- $categories := .Language.Params.Taxonomies.category | default "categories" }}
-    {{ $categoryColors := .Params.categoryColors }}
-    <div class="post-cat-div">
-      <ul class="post-categories">
-        {{- range ($.GetTerms $categories) }}
-        {{- if $categoryColors }}
-        {{- $color := index $categoryColors .LinkTitle }}
-        <li><a style="background: linear-gradient(to right, {{ $color.gradientStart }}, {{ $color.gradientEnd }}); -webkit-background-clip: text" href="{{ .Permalink }}">{{ .LinkTitle }}</a></li>
-        {{- else }}
-        <li><a href="{{ .Permalink }}">{{ .LinkTitle }}</a></li>
-        {{- end }}
-        {{- end }}
-      </ul>
+      {{- partial "category_tags.html" . -}}
     </div>
     {{- end }}
   </header>

--- a/themes/PaperMod/layouts/_default/single.html
+++ b/themes/PaperMod/layouts/_default/single.html
@@ -20,10 +20,16 @@
       {{- partial "post_canonical.html" . -}}
     </div>
     {{- $categories := .Language.Params.Taxonomies.category | default "categories" }}
+    {{ $categoryColors := .Params.categoryColors }}
     <div class="post-cat-div">
       <ul class="post-categories">
         {{- range ($.GetTerms $categories) }}
+        {{- if $categoryColors }}
+        {{- $color := index $categoryColors .LinkTitle }}
+        <li><a style="background: linear-gradient(to right, {{ $color.gradientStart }}, {{ $color.gradientEnd }}); -webkit-background-clip: text" href="{{ .Permalink }}">{{ .LinkTitle }}</a></li>
+        {{- else }}
         <li><a href="{{ .Permalink }}">{{ .LinkTitle }}</a></li>
+        {{- end }}
         {{- end }}
       </ul>
     </div>

--- a/themes/PaperMod/layouts/partials/category_tags.html
+++ b/themes/PaperMod/layouts/partials/category_tags.html
@@ -1,0 +1,18 @@
+{{- $categories := .Language.Params.Taxonomies.category | default "categories"
+}} {{ $categoryColors := .Params.categoryColors }}
+<div class="post-cat-div">
+  <ul class="post-categories">
+    {{- range ($.GetTerms $categories) }} {{- if $categoryColors }} {{- $color
+    := index $categoryColors .LinkTitle }}
+    <li>
+      <a
+        style="background: linear-gradient(to right, {{ $color.gradientStart }}, {{ $color.gradientEnd }}); -webkit-background-clip: text"
+        href="{{ .Permalink }}"
+        >{{ .LinkTitle }}</a
+      >
+    </li>
+    {{- else }}
+    <li><a href="{{ .Permalink }}">{{ .LinkTitle }}</a></li>
+    {{- end }} {{- end }}
+  </ul>
+</div>


### PR DESCRIPTION
# Variable Category Gradients

This pull request enables variable category gradients through CSS and Hugo page frontmatter. You can now define the gradients you want applied to the category tags at the top of blog posts.

## Example Usage

```yaml
categories: ["engineering", "open source", "devops"] # high level categories
categoryColors:
  engineering:
    gradientStart: "#007FEE"
    gradientEnd: "#00DBD8"
  open source:
    gradientStart: "#7E25C7"
    gradientEnd: "#F90183"
  devops:
    gradientStart: "#FF524C"
    gradientEnd: "#F9C52A"
```

How it renders:

<img width="858" alt="Screenshot 2023-08-12 at 11 53 28 AM" src="https://github.com/GrantBirki/blog/assets/23362539/a524381f-f4b4-486f-a49f-5db704238b87">

